### PR TITLE
Mount data drive by UUID instead of drive letter

### DIFF
--- a/config-dev-machine.md
+++ b/config-dev-machine.md
@@ -57,14 +57,16 @@ lsblk
 # Create mount point (Don't use /mnt since it's the temporary storage on Azure VM)
 sudo mkdir -p /mount/d
 
+# Find the UUID of the storage device, since /dev/sdc may change drive letters on reboot
+sudo blkid | grep UUID=
 
-# Configure auto mount (modify /dev/sdc if your disk is not attached there)
+# Configure auto mount (modify the disk device to include the UUID from above)
 cat << EOF | sudo tee /etc/systemd/system/mount-d.mount
 [Unit]
 Description=Mount Data Disk
 
 [Mount]
-What=/dev/sdc
+What=/dev/disk/by-uuid/<UUID>
 Where=/mount/d
 Type=ext4
 


### PR DESCRIPTION
I used the recipe in  `config-dev-machine.md` to set up a development box in Azure. Works great! The only change I made initially was to use Ubuntu 22.04 LTS with the `--image Canonical:0001-com-ubuntu-server-jammy:22_04-lts:latest` argument.

But every time it reboots, the data drive is assigned to a different drive letter. So this updates the recipe to mount by disk UUID instead, which is more resilient.

Hope this helps someone!